### PR TITLE
Embed fonts using TH

### DIFF
--- a/Graphics/PDF/Fonts/Font.hs
+++ b/Graphics/PDF/Fonts/Font.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE StandaloneDeriving #-}
 ---------------------------------------------------------
 -- |
 -- Copyright   : (c) 2006-2016, alpheccar.org
@@ -80,7 +81,9 @@ class IsFont f where
     spaceGlyph :: f -> GlyphCode
     charGlyph :: f -> Char  -> GlyphCode 
 
-data AnyFont = forall f. (IsFont f,PdfResourceObject f) => AnyFont f
+data AnyFont = forall f. (IsFont f,PdfResourceObject f,Show f) => AnyFont f
+
+deriving instance Show AnyFont
 
 instance PdfResourceObject AnyFont where
    toRsrc (AnyFont f) = toRsrc f

--- a/Graphics/PDF/Fonts/FontTypes.hs
+++ b/Graphics/PDF/Fonts/FontTypes.hs
@@ -12,10 +12,11 @@
 ---------------------------------------------------------
 -- #hide
 module Graphics.PDF.Fonts.FontTypes
-   ( GlyphSize
+   ( GlyphSize(..)
    , FontSize 
    , FontStructure(..)
    , GlyphPair(..)
+   , GlyphCode(..)
    , FontData(..)
    , mkFlags
    )
@@ -31,9 +32,9 @@ import Data.Bits hiding(bit)
 type FontSize = Int
 
 
-newtype GlyphSize = GlyphSize Int deriving(Eq,Ord,Num,Integral,Enum,Real)
+newtype GlyphSize = GlyphSize Int deriving(Eq,Ord,Num,Integral,Enum,Real,Show)
 
-data GlyphPair = GlyphPair !GlyphCode !GlyphCode deriving(Eq,Ord) 
+data GlyphPair = GlyphPair !GlyphCode !GlyphCode deriving(Eq,Ord,Show) 
 
 data FontStructure = FS { baseFont :: String
                         , descent :: !GlyphSize 
@@ -56,7 +57,7 @@ data FontStructure = FS { baseFont :: String
                         , allCap :: !Bool 
                         , smallCap :: !Bool 
                         , forceBold :: !Bool 
-                        }
+                        } deriving Show
 
 mkFlags :: FontStructure -> Word32 
 mkFlags fs = bit (fixedPitch fs) 1 .|. 

--- a/Graphics/PDF/Fonts/Type1.hs
+++ b/Graphics/PDF/Fonts/Type1.hs
@@ -32,7 +32,7 @@ import Graphics.PDF.Fonts.FontTypes
 import Graphics.PDF.Fonts.AFMParser (AFMFont, getFont, parseFont)
 import Data.List
 
-data Type1Font = Type1Font FontStructure (PDFReference EmbeddedFont)
+data Type1Font = Type1Font FontStructure (PDFReference EmbeddedFont) deriving Show
 
 instance IsFont Type1Font where 
   getDescent (Type1Font fs _) s = trueSize s $ descent fs 
@@ -44,7 +44,7 @@ instance IsFont Type1Font where
   hyphenGlyph (Type1Font fs _) = hyphen fs 
   spaceGlyph (Type1Font fs _) = space fs
 
-data AFMData = AFMData AFMFont 
+data AFMData = AFMData AFMFont deriving Show
 data Type1FontStructure = Type1FontStructure FontData FontStructure
 
 getAfmData :: FilePath -> IO AFMData 

--- a/HPDF.cabal
+++ b/HPDF.cabal
@@ -87,6 +87,7 @@ library
       network-uri >= 2.6.0.3,
       parsec >=3.1.9,
       filepath >= 1.4.0,
+      file-embed,
       hyphenation
   Default-language:  Haskell2010
 
@@ -105,6 +106,7 @@ library
      Graphics.PDF.Shapes
      Graphics.PDF.Text
      Graphics.PDF.Fonts.Font
+     Graphics.PDF.Fonts.FontTypes
      Graphics.PDF.Fonts.StandardFont
      Graphics.PDF.Fonts.Type1
      Graphics.PDF.Typesetting.WritingSystem
@@ -119,7 +121,6 @@ library
   Other-Modules:
      Paths_HPDF
      Graphics.PDF.LowLevel.Types
-     Graphics.PDF.Fonts.FontTypes
      Graphics.PDF.Data.PDFTree
      Graphics.PDF.Data.Trie
      Graphics.PDF.Pages


### PR DESCRIPTION
`mkStdFont` will fail on systems where the library is not installed (this would happen for example when a compiled binary is copied to a production server).

This PR embeds all `amf` files in the library itself using TH. It also exposes some internal data structures and adds `Show` instances for easier inspection where appropriate, which might be useful in some cases.