### PR TITLE
Revert data-files, Hackage upload broken

### DIFF
--- a/HPDF.cabal
+++ b/HPDF.cabal
@@ -20,6 +20,26 @@ extra-source-files:
   README.md
   TODO.txt
   changelog.md
+data-files:
+  Core14_AFMs/Courier-Bold.afm
+  Core14_AFMs/Helvetica-BoldOblique.afm
+  Core14_AFMs/Times-Bold.afm
+  Core14_AFMs/Courier-BoldOblique.afm
+  Core14_AFMs/Helvetica-Oblique.afm
+  Core14_AFMs/Times-BoldItalic.afm
+  Core14_AFMs/Courier-Oblique.afm
+  Core14_AFMs/Helvetica.afm
+  Core14_AFMs/Times-Italic.afm
+  Core14_AFMs/Courier.afm
+  Core14_AFMs/MustRead.html
+  Core14_AFMs/Times-Roman.afm
+  Core14_AFMs/Helvetica-Bold.afm
+  Core14_AFMs/Symbol.afm
+  Core14_AFMs/ZapfDingbats.afm
+  Encodings/glyphlist.txt
+  Encodings/zapfdingbats.txt
+  Encodings/pdfencodings.txt
+  Test/logo.jpg
 
 source-repository head
   type:     git


### PR DESCRIPTION
The newest [Hackage upload](https://hackage.haskell.org/package/HPDF-1.5.2/src/) doesn't contain the `Core14_AFMs` and the `Encodings` folders, so compilation fails at the `embedFile` splices.

Not sure why this is happening, my guess is maybe because we removed `data-files` from the `cabal` file? This PR reintroduces the `data-file` clause, hopefully that fixes it.

Btw, because this is something that's not said often enough to maintainers, I'd like to thank you for your free time and the quick responses and Hackage uploads and making my life easier :)