### PR TITLE
Allow parsing Afm-data from a ByteString

### DIFF
--- a/Graphics/PDF/Fonts/AFMParser.hs
+++ b/Graphics/PDF/Fonts/AFMParser.hs
@@ -14,12 +14,12 @@
 -- AFM AFMParser
 ---------------------------------------------------------
 module Graphics.PDF.Fonts.AFMParser(
-      getFont
-    , AFMFont(..)
+      AFMFont(..)
     , EncodingScheme(..)
     , Metric(..)
     , KX(..)
     , parseAfm
+    , fontToStructure
     ) where 
 
 import Data.ByteString (ByteString)
@@ -342,8 +342,8 @@ addKern d (KX sa sb c) fs =
 -- Otherwise we use the encoding we found in the afm file.
 -- It is used to force MacRomanEncoding on not symbolic default fonts.
 fontToStructure :: AFMFont 
-                -> M.Map PostscriptName Char 
-                -> Maybe (M.Map PostscriptName GlyphCode)
+                -> M.Map PostscriptName Char   -- ^ Glyph name to unicode
+                -> Maybe (M.Map PostscriptName GlyphCode)  -- ^ Glyph name to glyph code if not standard coding
                 -> FontStructure 
 fontToStructure afm' encoding' maybeMapNameToGlyph =
   let h = (afmAscent afm' - afmDescent afm') 
@@ -386,13 +386,3 @@ afmParseFromFile p path bs = runParser p emptyAFM path (unpack bs)
 
 parseAfm :: FilePath -> ByteString -> Either ParseError AFMFont
 parseAfm = afmParseFromFile afm
-
-getFont :: Either ByteString AFMFont
-        -> M.Map PostscriptName Char  -- ^ Glyph name to unicode
-        -> Maybe (M.Map PostscriptName GlyphCode)  -- ^ Glyph name to glyph code if not standard coding
-        -> IO (Maybe FontStructure)
-getFont (Left s) encoding' nameToGlyph = do 
-  case parseAfm "<embedded>" s of 
-    Left _ -> return Nothing 
-    Right r -> return (Just $ fontToStructure r encoding' nameToGlyph)
-getFont (Right result) encoding' nameToGlyph = return . Just $ fontToStructure result encoding' nameToGlyph

--- a/Graphics/PDF/Fonts/AFMParser.hs
+++ b/Graphics/PDF/Fonts/AFMParser.hs
@@ -386,18 +386,11 @@ afmParseFromFile :: AFMParser AFMFont -> FilePath -> ByteString -> IO (Either Pa
 afmParseFromFile p path bs = do 
   return $ runParser p emptyAFM path (unpack bs)
 
-parseFont :: Either ByteString String -> IO (Maybe AFMFont)
-parseFont (Left bs) = do
-    r <- afmParseFromFile afm "<embedded>" bs
-    case r of
-      Left e -> error (show e)
-      Right r' -> return $ Just r'
+parseFont :: Either ByteString String -> IO (Either ParseError AFMFont)
+parseFont (Left bs) = afmParseFromFile afm "<embedded>" bs
 parseFont (Right path) = do
     bs <- B.readFile path
-    r <- afmParseFromFile afm path bs
-    case r of
-      Left e -> error (show e)
-      Right r' -> return $ Just r'
+    afmParseFromFile afm path bs
 
 getFont :: Either ByteString AFMFont
         -> M.Map PostscriptName Char  -- ^ Glyph name to unicode
@@ -409,4 +402,3 @@ getFont (Left s) encoding' nameToGlyph = do
     Nothing -> return Nothing 
     Just r -> return (Just $ fontToStructure r encoding' nameToGlyph)
 getFont (Right result) encoding' nameToGlyph = return . Just $ fontToStructure result encoding' nameToGlyph
-

--- a/Graphics/PDF/Fonts/AFMParser.hs
+++ b/Graphics/PDF/Fonts/AFMParser.hs
@@ -19,7 +19,7 @@ module Graphics.PDF.Fonts.AFMParser(
     , EncodingScheme(..)
     , Metric(..)
     , KX(..)
-    , parseFont
+    , afmParseFromFile
     ) where 
 
 import Data.ByteString (ByteString)
@@ -382,15 +382,8 @@ fontToStructure afm' encoding' maybeMapNameToGlyph =
     Nothing -> fs2
     Just k -> foldr (addKern nameToGlyph) fs2 k
 
-afmParseFromFile :: AFMParser AFMFont -> FilePath -> ByteString -> IO (Either ParseError AFMFont)
-afmParseFromFile p path bs = do 
-  return $ runParser p emptyAFM path (unpack bs)
-
-parseFont :: Either ByteString String -> IO (Either ParseError AFMFont)
-parseFont (Left bs) = afmParseFromFile afm "<embedded>" bs
-parseFont (Right path) = do
-    bs <- B.readFile path
-    afmParseFromFile afm path bs
+afmParseFromFile :: AFMParser AFMFont -> FilePath -> ByteString -> Either ParseError AFMFont
+afmParseFromFile p path bs = runParser p emptyAFM path (unpack bs)
 
 getFont :: Either ByteString AFMFont
         -> M.Map PostscriptName Char  -- ^ Glyph name to unicode

--- a/Graphics/PDF/Fonts/Type1.hs
+++ b/Graphics/PDF/Fonts/Type1.hs
@@ -19,6 +19,7 @@ module Graphics.PDF.Fonts.Type1(
     , AFMData
     , Type1FontStructure(..)
     , getAfmData
+    , parseAfmData
     , mkType1FontStructure
 ) where 
 
@@ -54,7 +55,7 @@ getAfmData path = do
     return (AFMData r)
 
 parseAfmData :: B.ByteString -> IO AFMData
-pareAfmData bs = do
+parseAfmData bs = do
     Just r <- parseFont (Left bs)
     return (AFMData r)
 

--- a/Graphics/PDF/Fonts/Type1.hs
+++ b/Graphics/PDF/Fonts/Type1.hs
@@ -51,10 +51,10 @@ data AFMData = AFMData AFMFont deriving Show
 data Type1FontStructure = Type1FontStructure FontData FontStructure
 
 getAfmData :: FilePath -> IO (Either ParseError AFMData)
-getAfmData path = afmParseFromFile afm path <$> B.readFile path
+getAfmData path = first AFMData . afmParseFromFile afm path <$> B.readFile path
 
 parseAfmData :: B.ByteString -> Either ParseError AFMData
-parseAfmData bs = afmParseFromFile afm "<embedded>" bs
+parseAfmData bs = first AFMData $ afmParseFromFile afm "<embedded>" bs
 
 mkType1FontStructure :: FontData -> AFMData -> IO (Maybe Type1FontStructure)
 mkType1FontStructure pdfRef (AFMData f)  = do

--- a/Graphics/PDF/Fonts/Type1.hs
+++ b/Graphics/PDF/Fonts/Type1.hs
@@ -18,7 +18,7 @@ module Graphics.PDF.Fonts.Type1(
     , Type1Font(..)
     , AFMData
     , Type1FontStructure(..)
-    , getAfmData
+    , readAfmData
     , parseAfmData
     , mkType1FontStructure
 ) where 
@@ -50,8 +50,8 @@ instance IsFont Type1Font where
 data AFMData = AFMData AFMFont deriving Show
 data Type1FontStructure = Type1FontStructure FontData FontStructure
 
-getAfmData :: FilePath -> IO (Either ParseError AFMData)
-getAfmData path = first AFMData . afmParseFromFile afm path <$> B.readFile path
+readAfmData :: FilePath -> IO (Either ParseError AFMData)
+readAfmData path = first AFMData . afmParseFromFile afm path <$> B.readFile path
 
 parseAfmData :: B.ByteString -> Either ParseError AFMData
 parseAfmData bs = first AFMData $ afmParseFromFile afm "<embedded>" bs

--- a/Graphics/PDF/Fonts/Type1.hs
+++ b/Graphics/PDF/Fonts/Type1.hs
@@ -53,7 +53,7 @@ data Type1FontStructure = Type1FontStructure FontData FontStructure
 getAfmData :: FilePath -> IO (Either ParseError AFMData)
 getAfmData = first AFMData . parseFont . Right
 
-parseAfmData :: B.ByteString -> IO AFMData
+parseAfmData :: B.ByteString -> IO (Either ParseError AFMData)
 parseAfmData = first AFMData . parseFont . Left
 
 mkType1FontStructure :: FontData -> AFMData -> IO (Maybe Type1FontStructure)

--- a/Graphics/PDF/Fonts/Type1.hs
+++ b/Graphics/PDF/Fonts/Type1.hs
@@ -30,6 +30,7 @@ import Graphics.PDF.Fonts.Font
 import Graphics.PDF.Fonts.Encoding
 import Graphics.PDF.Fonts.FontTypes
 import Graphics.PDF.Fonts.AFMParser (AFMFont, getFont, parseFont)
+import qualified Data.ByteString as B
 import Data.List
 
 data Type1Font = Type1Font FontStructure (PDFReference EmbeddedFont) deriving Show
@@ -50,6 +51,11 @@ data Type1FontStructure = Type1FontStructure FontData FontStructure
 getAfmData :: FilePath -> IO AFMData 
 getAfmData path = do  
     Just r <- parseFont (Right path) 
+    return (AFMData r)
+
+parseAfmData :: B.ByteString -> IO AFMData
+pareAfmData bs = do
+    Just r <- parseFont (Left bs)
     return (AFMData r)
 
 mkType1FontStructure :: FontData -> AFMData -> IO (Maybe Type1FontStructure)

--- a/Graphics/PDF/Fonts/Type1.hs
+++ b/Graphics/PDF/Fonts/Type1.hs
@@ -33,6 +33,7 @@ import Graphics.PDF.Fonts.FontTypes
 import Graphics.PDF.Fonts.AFMParser (AFMFont, getFont, parseFont)
 import qualified Data.ByteString as B
 import Data.List
+import Data.Bifunctor (Bifunctor(first))
 
 data Type1Font = Type1Font FontStructure (PDFReference EmbeddedFont) deriving Show
 
@@ -49,15 +50,11 @@ instance IsFont Type1Font where
 data AFMData = AFMData AFMFont deriving Show
 data Type1FontStructure = Type1FontStructure FontData FontStructure
 
-getAfmData :: FilePath -> IO AFMData 
-getAfmData path = do  
-    Just r <- parseFont (Right path) 
-    return (AFMData r)
+getAfmData :: FilePath -> IO (Either ParseError AFMData)
+getAfmData = first AFMData . parseFont . Right
 
 parseAfmData :: B.ByteString -> IO AFMData
-parseAfmData bs = do
-    Just r <- parseFont (Left bs)
-    return (AFMData r)
+parseAfmData = first AFMData . parseFont . Left
 
 mkType1FontStructure :: FontData -> AFMData -> IO (Maybe Type1FontStructure)
 mkType1FontStructure pdfRef (AFMData f)  = do

--- a/Graphics/PDF/Fonts/Type1.hs
+++ b/Graphics/PDF/Fonts/Type1.hs
@@ -30,7 +30,7 @@ import Graphics.PDF.Fonts.Font
 -- import Graphics.PDF.Fonts.AFMParser
 import Graphics.PDF.Fonts.Encoding
 import Graphics.PDF.Fonts.FontTypes
-import Graphics.PDF.Fonts.AFMParser (AFMFont, getFont, parseFont)
+import Graphics.PDF.Fonts.AFMParser (AFMFont, getFont, afmParseFromFile)
 import qualified Data.ByteString as B
 import Data.List
 import Data.Bifunctor (Bifunctor(first))
@@ -51,10 +51,10 @@ data AFMData = AFMData AFMFont deriving Show
 data Type1FontStructure = Type1FontStructure FontData FontStructure
 
 getAfmData :: FilePath -> IO (Either ParseError AFMData)
-getAfmData = first AFMData . parseFont . Right
+getAfmData path = afmParseFromFile afm path <$> B.readFile path
 
-parseAfmData :: B.ByteString -> IO (Either ParseError AFMData)
-parseAfmData = first AFMData . parseFont . Left
+parseAfmData :: B.ByteString -> Either ParseError AFMData
+parseAfmData bs = afmParseFromFile afm "<embedded>" bs
 
 mkType1FontStructure :: FontData -> AFMData -> IO (Maybe Type1FontStructure)
 mkType1FontStructure pdfRef (AFMData f)  = do

--- a/Graphics/PDF/Fonts/Type1.hs
+++ b/Graphics/PDF/Fonts/Type1.hs
@@ -30,7 +30,7 @@ import Graphics.PDF.Fonts.Font
 -- import Graphics.PDF.Fonts.AFMParser
 import Graphics.PDF.Fonts.Encoding
 import Graphics.PDF.Fonts.FontTypes
-import Graphics.PDF.Fonts.AFMParser (AFMFont, getFont, parseAfm)
+import Graphics.PDF.Fonts.AFMParser (AFMFont, fontToStructure, parseAfm)
 import qualified Data.ByteString as B
 import Data.List
 import Data.Bifunctor (Bifunctor(second))
@@ -60,8 +60,7 @@ parseAfmData bs = second AFMData $ parseAfm "<bytestring>" bs
 mkType1FontStructure :: FontData -> AFMData -> IO Type1FontStructure
 mkType1FontStructure pdfRef (AFMData f)  = do
   theEncoding <- getEncoding AdobeStandardEncoding
-  -- a Right input to getFont always returns a Just
-  Just theFont <- getFont (Right f) theEncoding Nothing
+  let theFont = fontToStructure f theEncoding Nothing
   return $ Type1FontStructure pdfRef theFont
 
  

--- a/HPDF.cabal
+++ b/HPDF.cabal
@@ -1,5 +1,5 @@
 Name: HPDF
-Version: 1.5.4
+Version: 1.6.0
 cabal-version: >=1.10
 License: BSD3
 License-file:LICENSE
@@ -132,4 +132,3 @@ library
      Graphics.PDF.Typesetting.StandardStyle
      Graphics.PDF.Fonts.AFMParser
      Graphics.PDF.Fonts.Encoding
-

--- a/HPDF.cabal
+++ b/HPDF.cabal
@@ -1,5 +1,5 @@
 Name: HPDF
-Version: 1.5.3
+Version: 1.5.4
 cabal-version: >=1.10
 License: BSD3
 License-file:LICENSE

--- a/Test/test.hs
+++ b/Test/test.hs
@@ -689,11 +689,11 @@ testAll timesRoman timesBold helveticaBold symbol zapf jpg = do
 main :: IO()
 main = do
     let rect = PDFRect 0 0 600 400
-    Just timesRoman <- mkStdFont Times_Roman 
-    Just timesBold <- mkStdFont Times_Bold
-    Just helveticaBold <- mkStdFont Helvetica_Bold
-    Just symbol <- mkStdFont Symbol 
-    Just zapf <- mkStdFont ZapfDingbats
+    Right timesRoman <- mkStdFont Times_Roman 
+    Right timesBold <- mkStdFont Times_Bold
+    Right helveticaBold <- mkStdFont Helvetica_Bold
+    Right symbol <- mkStdFont Symbol 
+    Right zapf <- mkStdFont ZapfDingbats
 
     let logoPath = "Test/logo.jpg"
     Right jpg <- readJpegFile logoPath


### PR DESCRIPTION
Expose a function to parse a font from a ByteString.
This way it is possible to embed other fonts in the binary, not only the provided ones.