### PR TITLE
Specify encoding when loading type1 font

### DIFF
--- a/Graphics/PDF.hs
+++ b/Graphics/PDF.hs
@@ -72,7 +72,10 @@ module Graphics.PDF
   , module Graphics.PDF.Fonts.StandardFont
   , module Graphics.PDF.Fonts.Type1
   , readType1Font
+  , readType1FontWithEncoding
   , mkType1Font
+  , PostscriptName
+  , Encodings(..)
   -- ** Typesetting
   , module Graphics.PDF.Typesetting
   ) where
@@ -112,6 +115,7 @@ import qualified Data.Text as T
 import Graphics.PDF.Fonts.Font 
 import Graphics.PDF.Fonts.StandardFont
 import Graphics.PDF.Fonts.Type1
+import Graphics.PDF.Fonts.Encoding (Encodings(..), PostscriptName)
 
 -- | Create a new PDF document and return a first page
 -- The page is using the document size by default

--- a/Graphics/PDF.hs
+++ b/Graphics/PDF.hs
@@ -76,6 +76,7 @@ module Graphics.PDF
   , mkType1Font
   , PostscriptName
   , Encodings(..)
+  , unionEncodings
   -- ** Typesetting
   , module Graphics.PDF.Typesetting
   ) where
@@ -115,7 +116,7 @@ import qualified Data.Text as T
 import Graphics.PDF.Fonts.Font 
 import Graphics.PDF.Fonts.StandardFont
 import Graphics.PDF.Fonts.Type1
-import Graphics.PDF.Fonts.Encoding (Encodings(..), PostscriptName)
+import Graphics.PDF.Fonts.Encoding (unionEncodings, Encodings(..), PostscriptName)
 
 -- | Create a new PDF document and return a first page
 -- The page is using the document size by default

--- a/Graphics/PDF/Fonts/Encoding.hs
+++ b/Graphics/PDF/Fonts/Encoding.hs
@@ -15,6 +15,7 @@
 ---------------------------------------------------------
 module Graphics.PDF.Fonts.Encoding(
       getEncoding
+    , unionEncodings
     , Encodings(..)
     , PostscriptName
     , parseMacEncoding
@@ -75,3 +76,13 @@ getEncoding :: Encodings -> IO (M.Map PostscriptName Char)
 getEncoding AdobeStandardEncoding = parseGlyphListEncoding glyphlist
 getEncoding ZapfDingbatsEncoding= parseGlyphListEncoding zapfdingbats
 getEncoding (OtherEncoding enc) = pure enc
+
+-- Merge two encodings enc1 and enc2; it prefers enc1 when duplicate keys are encountered
+--
+-- This example will overwrite the glyph name "a" in AdobeStandardEncoding:
+-- >>> unionEncodings (OtherEncoding (M.singleton "a" '☃')) AdobeStandardEncoding
+unionEncodings :: Encodings -> Encodings -> IO Encodings
+unionEncodings enc1 enc2 = do
+  edata1 <- getEncoding enc1
+  edata2 <- getEncoding enc2
+  pure (OtherEncoding (M.union edata1 edata2))

--- a/Graphics/PDF/Fonts/Encoding.hs
+++ b/Graphics/PDF/Fonts/Encoding.hs
@@ -32,6 +32,7 @@ type PostscriptName = String
 
 data Encodings = AdobeStandardEncoding
                | ZapfDingbatsEncoding
+               | OtherEncoding (M.Map PostscriptName Char)
                deriving(Eq)
 
 isLine :: C.ByteString -> Bool
@@ -73,3 +74,4 @@ zapfdingbats = $(embedFile "Encodings/zapfdingbats.txt")
 getEncoding :: Encodings -> IO (M.Map PostscriptName Char)
 getEncoding AdobeStandardEncoding = parseGlyphListEncoding glyphlist
 getEncoding ZapfDingbatsEncoding= parseGlyphListEncoding zapfdingbats
+getEncoding (OtherEncoding enc) = pure enc

--- a/Graphics/PDF/Fonts/Type1.hs
+++ b/Graphics/PDF/Fonts/Type1.hs
@@ -57,9 +57,9 @@ readAfmData path = second AFMData . parseAfm path <$> B.readFile path
 parseAfmData :: B.ByteString -> Either ParseError AFMData
 parseAfmData bs = second AFMData $ parseAfm "<bytestring>" bs
 
-mkType1FontStructure :: FontData -> AFMData -> IO Type1FontStructure
-mkType1FontStructure pdfRef (AFMData f)  = do
-  theEncoding <- getEncoding AdobeStandardEncoding
+mkType1FontStructure :: Encodings -> FontData -> AFMData -> IO Type1FontStructure
+mkType1FontStructure encoding pdfRef (AFMData f)  = do
+  theEncoding <- getEncoding encoding
   let theFont = fontToStructure f theEncoding Nothing
   return $ Type1FontStructure pdfRef theFont
 

--- a/Test/onepage.hs
+++ b/Test/onepage.hs
@@ -79,8 +79,8 @@ testAll theFont@(PDFFont f s) = do
         
 main :: IO()
 main = do
-    fontData <- readType1Font testFont afm
-    Just timesRoman <- mkStdFont Times_Roman 
+    Right fontData <- readType1Font testFont afm
+    Right timesRoman <- mkStdFont Times_Roman
     let rect = PDFRect 0 0 600 400
     runPdf "demo.pdf" (standardDocInfo { author= "alpheccar éèçàü", compressed = False}) rect $ do
         testFont <- mkType1Font fontData


### PR DESCRIPTION
c.f. https://github.com/hsyl20/HPDF/issues/9 this lets us do things like

```hs
main = do
   …
    Right azsubscriptStructure <- readType1FontWithEncoding (OtherEncoding subscriptEncoding) 
                                                           "./azsubscripts.pfb" "./azsubscripts.afm"
    run (standardDocInfo { author = "me", compressed = False }) docRect $ do
        azsubscriptFont <- mkType1Font azsubscriptStructure
        makeDocument azsubscriptFont …

subscriptEncoding :: M.Map String Char
subscriptEncoding = M.fromList
  [ ("uni2080",'₀')
  , ("uni2081",'₁')
  , ("uni2082",'₂')
  , ("uni2083",'₃')
  , ("uni2084",'₄')
  , ("uni2085",'₅')
  , ("uni2086",'₆')
  , ("uni2087",'₇')
  , ("uni2088",'₈')
  , ("uni2089",'₉')
  ]
```

I use these helpers to pick fonts:

```hs
         txtWithFont fontPicker textThatMightHaveSubscripts
         forceNewLine
  where
    fontPicker c
        | c `elem` subscriptEncoding = Normal azsubscriptFont
        | otherwise              = Normal timesRoman

txtWithFont :: (Char -> MyParaStyles) -> Text -> Para MyParaStyles ()
txtWithFont pickFont text = for_ broken styleChar
  where
    broken = groupWithKey pickFont (T.unpack text)
    styleChar :: (MyParaStyles, String) -> Para MyParaStyles ()
    styleChar (style, substring) = do 
                        setStyle style
                        txt (T.pack substring)

groupWithKey :: Eq key => (elt -> key) -> [elt] -> [(key, [elt])]
groupWithKey classify lst = fmap decorate lst |> Data.List.Extra.groupOnKey fst |> map (second (map snd))
  where
    decorate elt = (classify elt, elt)
```

------

Note: there are some functions like `getEncoding` that I don't understand why are in IO, but I haven't changed them (perhaps the idea was to keep the api general enough to add encodings that need IO at a later point?).

And like I said in the comments of #9 I have no idea what the best API here is, but at least this PR exposes the functions necessary to get something working, without exposing *that* much of the Encodings module.