### PR TITLE
Draw.return: remove method implementation for compatibility with MonadOfNoReturn

### DIFF
--- a/Graphics/PDF/Draw.hs
+++ b/Graphics/PDF/Draw.hs
@@ -214,7 +214,6 @@ instance Monad Draw where
     m >>= f  = Draw $ \env -> do
                           a <- unDraw m env
                           unDraw (f a) env
-    return x = Draw $ \_env -> return x
 
 instance MonadReader DrawEnvironment Draw where
    ask       = Draw $ \env -> return (drawEnvironment env)

--- a/HPDF.cabal
+++ b/HPDF.cabal
@@ -79,8 +79,8 @@ Executable HPDF-Demo
 
 library
   build-depends: 
-      base >= 4 && < 5, 
-      containers, 
+      base >= 4.8 && < 5,
+      containers,
       random >= 1.0, 
       bytestring >= 0.9, 
       array >= 0.1, 


### PR DESCRIPTION
Requires Cabal.Build-Depends: base>=4.8